### PR TITLE
Update param handling

### DIFF
--- a/nat-reflection/nat-reflection.sh
+++ b/nat-reflection/nat-reflection.sh
@@ -13,9 +13,9 @@ fi
 mkdir -p $RULES_PATH || { echo 'Error: Failed to create rules directory.'; exit 1; }
 
 function add_rule() {
-  local ip=$1
-  local dest=$2
-  iptables -t nat -A PREROUTING -d $ip -j DNAT --to-destination $dest || { echo "Error: Failed to add rule."; exit 1; }
+  local ip="$1"
+  local dest="$2"
+  iptables -t nat -A PREROUTING -d "$ip" -j DNAT --to-destination "$dest" || { echo "Error: Failed to add rule."; exit 1; }
   echo "$ip $dest" >> "$RULES_PATH/rules" || { echo 'Error: Failed to write rule to file.'; exit 1; }
   echo "Success: Rule added."
 }
@@ -25,9 +25,9 @@ function list_rules() {
 }
 
 function delete_rule() {
-  local ip=$1
-  local dest=$2
-  iptables -t nat -D PREROUTING -d $ip -j DNAT --to-destination $dest || { echo 'Error: Failed to delete rule.'; exit 1; }
+  local ip="$1"
+  local dest="$2"
+  iptables -t nat -D PREROUTING -d "$ip" -j DNAT --to-destination "$dest" || { echo 'Error: Failed to delete rule.'; exit 1; }
   sed -i "/$ip $dest/d" "$RULES_PATH/rules" || { echo 'Error: Failed to delete rule from file.'; exit 1; }
   echo "Success: Rule deleted."
 }
@@ -36,21 +36,21 @@ function reload_rules() {
   sleep 3
   while IFS=' ' read -r line; do
     IFS=' ' read -r ip dest <<<"$line"
-    iptables -t nat -D PREROUTING -d $ip -j DNAT --to-destination $dest >/dev/null 2>&1
-    iptables -t nat -A PREROUTING -d $ip -j DNAT --to-destination $dest || { echo "Error: Failed to reload rule."; exit 1; }
+    iptables -t nat -D PREROUTING -d "$ip" -j DNAT --to-destination "$dest" >/dev/null 2>&1
+    iptables -t nat -A PREROUTING -d "$ip" -j DNAT --to-destination "$dest" || { echo "Error: Failed to reload rule."; exit 1; }
   done < "$RULES_PATH/rules"
   echo "Success: Rules reloaded."
 }
 
 case "$1" in
   add)
-    add_rule $2 $3
+    add_rule "$2" "$3"
     ;;
   list)
     list_rules
     ;;
   delete)
-    delete_rule $2 $3
+    delete_rule "$2" "$3"
     ;;
   reload)
     reload_rules


### PR DESCRIPTION
Use double quotes when passing parameters to functions to handle variables with spaces or special characters correctly.